### PR TITLE
add arm64 binaries to GitHub releases

### DIFF
--- a/script/release
+++ b/script/release
@@ -6,5 +6,5 @@
 
 set -e
 latest_tag=$(git describe --abbrev=0 --tags)
-goxz -d dist/$latest_tag -z -os darwin,linux -arch amd64,386
+goxz -d dist/$latest_tag -z -os darwin,linux -arch amd64,386,arm64
 ghr -u mackerelio -r mackerel-plugin-json $latest_tag dist/$latest_tag


### PR DESCRIPTION
Title describes almost all.

With this p-r, we will provide {darwin,linux} x {arm64,amd64,386} binaries at GitHub releases.
Personally I don't think i386 binaries are necessary anymore, but I'd like to keep it as is for now.
(Especially i386 darwin binaries are only used in ancient Macs...)