### PR TITLE
do not try to build darwin-arm64

### DIFF
--- a/script/release
+++ b/script/release
@@ -6,5 +6,8 @@
 
 set -e
 latest_tag=$(git describe --abbrev=0 --tags)
-goxz -d dist/$latest_tag -z -os darwin,linux -arch amd64,386,arm64
+# TODO: after switch to go 1.16 (or later), we can migrate into those two lines into
+# one line like goxz -d dist/$latest_tag -z -os darwin,linux -arch amd64,386,arm64
+goxz -d dist/$latest_tag -z -os darwin -arch amd64,386
+goxz -d dist/$latest_tag -z -os linux -arch amd64,386,arm64
 ghr -u mackerelio -r mackerel-plugin-json $latest_tag dist/$latest_tag

--- a/script/release
+++ b/script/release
@@ -6,8 +6,6 @@
 
 set -e
 latest_tag=$(git describe --abbrev=0 --tags)
-# TODO: after switch to go 1.16 (or later), we can migrate into those two lines into
-# one line like goxz -d dist/$latest_tag -z -os darwin,linux -arch amd64,386,arm64
 goxz -d dist/$latest_tag -z -os darwin -arch amd64,386
 goxz -d dist/$latest_tag -z -os linux -arch amd64,386,arm64
 ghr -u mackerelio -r mackerel-plugin-json $latest_tag dist/$latest_tag


### PR DESCRIPTION
Current master fails build, because it tries to build `GOOS=darawin GOARCH=arm64`, which is not supported in current Golang https://github.com/mackerelio/mackerel-plugin-json/runs/1615993070

(And I noticed that `GOOS=darwin GOARCH=386` does not work anymore on go >= 1.15. We should remove this line soon...)