### PR TITLE
drop darwin/386

### DIFF
--- a/script/release
+++ b/script/release
@@ -6,6 +6,6 @@
 
 set -e
 latest_tag=$(git describe --abbrev=0 --tags)
-goxz -d dist/$latest_tag -z -os darwin -arch amd64,386
+goxz -d dist/$latest_tag -z -os darwin -arch amd64
 goxz -d dist/$latest_tag -z -os linux -arch amd64,386,arm64
 ghr -u mackerelio -r mackerel-plugin-json $latest_tag dist/$latest_tag


### PR DESCRIPTION
Remove darwin/386 from release script as it is no longer supported by Go.