### PR TITLE
Set CGO_ENABLED=0 in goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+    env:
+      - CGO_ENABLED=0
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
To avoid glibc dependencies trouble, set CGO_ENABLED=0 in goreleaser.yml